### PR TITLE
feat: Allow the user to filter either weekly or monthly

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -18,11 +18,12 @@ india = import_geojson('https://naciscdn.org/naturalearth/50m/cultural/ne_50m_ad
 preprocessed_data = preprocess_data(df)
 status_mapping = preprocessed_data["status_mapping"]
 month_labels = preprocessed_data["month_labels"]
+week_labels = preprocessed_data["week_labels"]
 
 # Create Components
 title = create_title()
 metrics = create_metrics()
-filters = create_filters(month_labels, status_mapping)
+filters = create_filters(month_labels, week_labels, status_mapping)
 visuals = create_visuals()
 footer = create_footer()
 

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -450,3 +450,19 @@ def toggle_time_selection_visibility(time_granularity):
             {'display': 'none'},   # Hide month label
             {'display': 'block', 'color': '#34495e', 'font-weight': 'bold'}  # Show week label
         )
+
+@callback(
+    Output("sales-chart-header", "children"),
+    Input("time_granularity", "value")
+)
+def update_sales_chart_header(time_granularity):
+    """
+    Update the sales chart header based on the selected time granularity.
+
+    Args:
+        time_granularity (str): "Monthly" or "Weekly" from the radio button.
+
+    Returns:
+        str: Updated header text.
+    """
+    return "Monthly Sales" if time_granularity == "Monthly" else "Weekly Sales"

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -44,14 +44,12 @@ def update_filtered_data(date_slider_value, week_range_value, promo_filter, fulf
         display_date = selected_date
     else:  # Weekly
         start_index, end_index = week_range_value  #Unpack the range slider values
-        print(f"start_index: {start_index}, end_index: {end_index}")
 
         all_weeks = list(week_labels.values())  # example -  ['2022-03-28/2022-04-03', '2022-04-04/2022-04-10']
         selected_weeks = all_weeks[start_index:end_index + 1]
         
         start_week = week_labels.get(start_index, None)
         end_week = week_labels.get(end_index, None)
-        print(f"start_week: {start_week}, end_week: {end_week}")
         
         if not start_week or not end_week:
             return "No selection", ""

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -84,42 +84,62 @@ def update_filtered_data(date_slider_value, week_range_value, promo_filter, fulf
     return f"Showing {filtered_df['order_count'].sum():,.0f} records for {display_date}.", filter_condition
 
 @callback(
-    Output("metric-1", "children"),  # Revenue metric
-    Output("metric-2", "children"),  # Quantity metric
-    Output("metric-3", "children"),  # Completion rate metric
-    Input("date-slider", "value"),
-    Input("promotion-toggle", "value"),
-    Input("fulfillment-radio", "value"),
-    Input("status-checkbox", "value"),
-    Input("map", "clickData"),
+    [Output("metric-1", "children"),  # Assuming these are the IDs of your metric cards
+     Output("metric-2", "children"),
+     Output("metric-3", "children")],
+    [Input("date-slider", "value"),       # Monthly slider value
+     Input("week-range-slider", "value"), # Week range slider value [start, end]
+     Input("promotion-toggle", "value"),
+     Input("fulfillment-radio", "value"),
+     Input("status-checkbox", "value"),
+     Input("map", "clickData"),
+     Input("time_granularity", "value")]  # Radio button for Monthly/Weekly
 )
-def update_metrics(selected_index, promo_filter, fulfillment_filter, selected_statuses, click_data):
+def update_metrics(date_slider_value, week_range_value, promo_filter, fulfillment_filter, selected_statuses, click_data, time_granularity):
     """
     Update the metric cards dynamically based on all filters.
 
     Args:
-        selected_index (int): Selected index from the date slider.
-        promo_filter (bool): Whether promotion filter is applied.
+        date_slider_value (int): Selected index from the date slider.
+        week_range_value (list): Selected [start, end] week indices from the range slider.
+        promo_filter (bool): Promotion filter toggle value.
         fulfillment_filter (str): Selected fulfillment type.
         selected_statuses (list): List of selected order statuses.
         click_data (dict): Data from map click event.
+        time_granularity (str): "Monthly" or "Weekly" - determines if filtering is based on months or weeks.
 
     Returns:
         tuple: Updated metric contents for revenue, quantity, and completion rate.
     """
-    # Convert slider index to corresponding year-month
-    selected_date = month_labels.get(selected_index, None)
+    if time_granularity == "Monthly":
+        selected_index = date_slider_value
+        selected_date = month_labels.get(selected_index, None)
+        if not selected_date:
+            return dbc.CardBody("N/A"), dbc.CardBody("N/A"), dbc.CardBody("N/A")
+        
+        selected_period = pd.to_datetime(f"{selected_date}-01")
+        previous_period = selected_period - pd.DateOffset(months=1)
+        previous_period_str = previous_period.strftime("%Y-%m")
+        filter_condition = f'year_month == "{selected_date}"'
+        period_type = "month"
+    else:  # Weekly
+        start_index, end_index = week_range_value
+        all_weeks = list(week_labels.values())
+        selected_weeks = all_weeks[start_index:end_index + 1]
+        
+        start_week = week_labels.get(start_index, None)
+        end_week = week_labels.get(end_index, None)
+        if not start_week or not end_week:
+            return dbc.CardBody("N/A"), dbc.CardBody("N/A"), dbc.CardBody("N/A")
+        
+        #for previous period, shift back by one week from the start week
+        prev_index = start_index - 1
+        previous_week = week_labels.get(prev_index, None) if prev_index >= 0 else None
+        previous_period_str = previous_week if previous_week else None
+        filter_condition = f'(year_week in {selected_weeks})'
+        period_type = "week"
 
-    if not selected_date:
-        return dbc.CardBody("N/A"), dbc.CardBody("N/A"), dbc.CardBody("N/A")
-
-    selected_month = pd.to_datetime(f"{selected_date}-01")
-    previous_month = selected_month - pd.DateOffset(months=1)
-    previous_month_str = previous_month.strftime("%Y-%m")
-
-    # Apply filters to dataset
-    filter_condition = f'year_month == "{selected_date}"'
-
+    # Apply additional filters
     if promo_filter:
         filter_condition += ' & (is_promotion == True)'
 
@@ -135,10 +155,10 @@ def update_metrics(selected_index, promo_filter, fulfillment_filter, selected_st
         state = click_data['points'][0]['location']
         filter_condition += f' & (state == "{state}")'
 
-    # Filter dataset for the selected month
+    # Filter dataset for the selected period
     filtered_df = df.query(filter_condition)
 
-    # Compute revenue, quantity, and completion rate for selected month
+    # Compute revenue, quantity, and completion rate for selected period
     revenue_selected = filtered_df["Amount"].sum()
     quantity_selected = filtered_df["Qty"].sum()
 
@@ -146,22 +166,23 @@ def update_metrics(selected_index, promo_filter, fulfillment_filter, selected_st
     completed_orders = filtered_df[filtered_df["Status"].isin(completed_status)]
     completion_rate_selected = (len(completed_orders) / len(filtered_df)) * 100 if len(filtered_df) > 0 else 0
 
-    # Compute the previous month's metrics
-    if previous_month_str in df["year_month"].unique():
-        prev_df = df.query(f'year_month == "{previous_month_str}"')
+    # Compute the previous period's metrics
+    if previous_period_str:
+        if period_type == "month":
+            prev_filter = f'year_month == "{previous_period_str}"'
+        else:  # week
+            prev_filter = f'year_week == "{previous_period_str}"'
 
         if promo_filter:
-            prev_df = prev_df[prev_df["is_promotion"] == True]
-
+            prev_filter += ' & (is_promotion == True)'
         if fulfillment_filter != "Both":
-            prev_df = prev_df[prev_df["Fulfilment"] == fulfillment_filter]
-
+            prev_filter += f' & (Fulfilment == "{fulfillment_filter}")'
         if selected_statuses:
-            prev_df = prev_df[prev_df["Status"].isin(filter_statuses)]
-
+            prev_filter += f' & (Status in [{filter_statuses_str}])'
         if click_data and 'points' in click_data:
-            prev_df = prev_df[prev_df["state"] == state]
+            prev_filter += f' & (state == "{state}")'
 
+        prev_df = df.query(prev_filter)
         revenue_prev = prev_df["Amount"].sum()
         quantity_prev = prev_df["Qty"].sum()
         completed_prev = prev_df[prev_df["Status"].isin(completed_status)]
@@ -179,11 +200,11 @@ def update_metrics(selected_index, promo_filter, fulfillment_filter, selected_st
     def format_mom_change(value):
         abs_value = abs(value)  # Get the absolute value (remove sign)
         if value > 0:
-            return html.Span([f"{abs_value:.1f}% ", "▲ ", " past month"], style={"color": "orange", "font-weight": "bold"})
+            return html.Span([f"{abs_value:.1f}% ", "▲ ", f" past {period_type}"], style={"color": "orange", "font-weight": "bold"})
         elif value < 0:
-            return html.Span([f"{abs_value:.1f}% ", "▼ ", " past month"], style={"color": "skyblue", "font-weight": "bold"})
+            return html.Span([f"{abs_value:.1f}% ", "▼ ", f" past {period_type}"], style={"color": "skyblue", "font-weight": "bold"})
         else:
-            return html.Span([f"{abs_value:.1f}% ", " past month"], style={"color": "gray", "font-weight": "bold"})
+            return html.Span([f"{abs_value:.1f}% ", f" past {period_type}"], style={"color": "gray", "font-weight": "bold"})
 
 
     # **Wrap metrics inside dbc.CardBody()**

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -4,17 +4,19 @@ import plotly.express as px
 import plotly.graph_objects as go
 import dash_bootstrap_components as dbc
 from dash import Input, Output, callback
-from .app import df, month_labels, status_mapping, india
+from .app import df, month_labels, week_labels, status_mapping, india
 from .components import format_large_num
 
 @callback(
     Output("filtered-data", "children"),  # Debugging output
     Output("filter_condition", "data"),
-    Input("date-slider", "value"),
+    Input("date-slider", "value"),       # Monthly slider value
+    Input("week-range-slider", "value"), # Week range slider value [start, end]
     Input("promotion-toggle", "value"),
     Input("fulfillment-radio", "value"),
     Input("status-checkbox", "value"),
     Input("map", "clickData"),
+    Input("time_granularity", "value")   # Radio button for Monthly/Weekly
 )
 def update_filtered_data(selected_index, promo_filter, fulfillment_filter, selected_statuses, click_data):
     """
@@ -357,3 +359,35 @@ def create_product_chart(query):
     except Exception as e:
         print(f"Error in create_product_chart: {e}")
         return go.Figure(data=[go.Scatter(x=[], y=[], mode='text', text=f"Error: {e}")])
+
+@callback(
+    Output('date-slider-container', 'style'),
+    Output('week-selector-container', 'style'),
+    Output('month-label', 'style'),
+    Output('week-label', 'style'),
+    Input('time_granularity', 'value')
+)
+def toggle_time_selection_visibility(time_granularity):
+    """
+    Toggle visibility of monthly slider and weekly dropdown based on time granularity selection.
+    
+    Args:
+        time_granularity (str): Selected value from the radio buttons ('Monthly' or 'Weekly')
+    
+    Returns:
+        tuple: Styles for date slider container, week selector container, month label, and week label
+    """
+    if time_granularity == 'Monthly':
+        return (
+            {'display': 'block'},  # Show monthly slider
+            {'display': 'none'},   # Hide weekly dropdown
+            {'display': 'block', 'color': '#34495e', 'font-weight': 'bold'},  # Show month label
+            {'display': 'none'}    # Hide week label
+        )
+    else:  # Weekly
+        return (
+            {'display': 'none'},   # Hide monthly slider
+            {'display': 'block'},  # Show weekly dropdown
+            {'display': 'none'},   # Hide month label
+            {'display': 'block', 'color': '#34495e', 'font-weight': 'bold'}  # Show week label
+        )

--- a/src/components.py
+++ b/src/components.py
@@ -106,6 +106,26 @@ def create_date_slider(month_labels):
         tooltip={"placement": "bottom", "always_visible": True},
     )
 
+def create_week_selector(week_labels):
+    """
+    Create a range slider for selecting a start and end week range.
+    
+    Args:
+        week_labels (dict): Mapping of week labels (e.g., {0: '2022-03-28/2022-04-03', ...}).
+    
+    Returns:
+        dcc.RangeSlider: Range slider component for week selection.
+    """
+    max_index = max(week_labels.keys())  # Get the maximum index for the slider range
+    return dcc.RangeSlider(
+        id="week-range-slider",
+        min=0,
+        max=max_index,
+        step=1,
+        value=[0, max_index],  # Default range: from earliest to latest week  # Show short date like "03-28"
+        tooltip={"placement": "bottom", "always_visible": True}
+    )
+
 def create_promotion_toggle():
     """
     Create the promotion toggle switch component for the dashboard.

--- a/src/components.py
+++ b/src/components.py
@@ -187,18 +187,20 @@ def create_status_checkbox(status_mapping):
         )
     ])
 
-def create_filters(month_labels, status_mapping):
+def create_filters(month_labels, week_labels, status_mapping):
     """
     Create the filters component for the dashboard.
     
     Args:
         month_labels (dict): Mapping of month labels for the date slider.
+        week_labels (dict): Mapping of week labels for the week selector.
         status_mapping (dict): Mapping of order statuses.
     
     Returns:
         dbc.Col: Filters component.
     """
     date_slider = create_date_slider(month_labels)
+    week_selector = create_week_selector(week_labels)
     promotion_toggle = create_promotion_toggle()
     fulfillment_radio = create_fulfillment_radio()
     status_checkbox = create_status_checkbox(status_mapping)
@@ -208,8 +210,20 @@ def create_filters(month_labels, status_mapping):
             dbc.CardBody([
                 html.H4("Filters", className="text-center mb-4", style={"font-weight": "bold", "color": "#2c3e50"}),
 
-                html.Label("Select Month:", className="fw-bold", style={"color": "#34495e"}),
-                date_slider,
+                dcc.RadioItems(
+                    id='time_granularity',
+                    options=[
+                        {'label': 'Monthly', 'value': 'Monthly'},
+                        {'label': 'Weekly', 'value': 'Weekly'}
+                    ],
+                    value='Monthly',  # Default value
+                    className="mb-3"
+                ),
+
+                html.Label("Select Month:", className="fw-bold", style={"color": "#34495e"}, id='month-label'),
+                html.Div(id='date-slider-container', children=date_slider),  # Wrap slider in a Div for styling
+                html.Label("Select Week:", className="fw-bold", style={"color": "#34495e"}, id='week-label'),
+                html.Div(id='week-selector-container', children=week_selector, style={'display': 'none'}),  # Initially hidden
                 html.Hr(),
 
                 html.Label("Promotions Only:", className="fw-bold mt-3", style={"color": "#34495e"}),

--- a/src/components.py
+++ b/src/components.py
@@ -122,7 +122,7 @@ def create_week_selector(week_labels):
         min=0,
         max=max_index,
         step=1,
-        value=[0, max_index],  # Default range: from earliest to latest week  # Show short date like "03-28"
+        value=[3, 9],  # Default range
         tooltip={"placement": "bottom", "always_visible": True}
     )
 

--- a/src/components.py
+++ b/src/components.py
@@ -168,6 +168,26 @@ def create_fulfillment_radio():
         )
     ], width=3)
 
+def create_time_radio():
+    """
+    Create the time granularity radio button component for the dashboard.
+    
+    Returns:
+        dbc.Col: Fulfillment radio button component.
+    """         
+    return dbc.Col([
+        dbc.RadioItems(
+            id="time_granularity",
+            options=[
+                {"label": " Monthly", "value": "Monthly"},
+                {"label": " Weekly", "value": "Weekly"}
+            ],
+            value="Monthly",
+            inline=False,
+            className="mt-2"
+        )
+    ], width=3)
+
 def create_status_checkbox(status_mapping):
     """
     Create the status checkbox component for the dashboard.
@@ -201,6 +221,7 @@ def create_filters(month_labels, week_labels, status_mapping):
     """
     date_slider = create_date_slider(month_labels)
     week_selector = create_week_selector(week_labels)
+    time_radio = create_time_radio()
     promotion_toggle = create_promotion_toggle()
     fulfillment_radio = create_fulfillment_radio()
     status_checkbox = create_status_checkbox(status_mapping)
@@ -209,17 +230,10 @@ def create_filters(month_labels, week_labels, status_mapping):
         dbc.Card(
             dbc.CardBody([
                 html.H4("Filters", className="text-center mb-4", style={"font-weight": "bold", "color": "#2c3e50"}),
-
-                dcc.RadioItems(
-                    id='time_granularity',
-                    options=[
-                        {'label': 'Monthly', 'value': 'Monthly'},
-                        {'label': 'Weekly', 'value': 'Weekly'}
-                    ],
-                    value='Monthly',  # Default value
-                    className="mb-3"
-                ),
-
+                
+                html.Label("Time Granularity:", className="fw-bold mt-3", style={"color": "#34495e"}),
+                time_radio,
+                html.Hr(),
                 html.Label("Select Month:", className="fw-bold", style={"color": "#34495e"}, id='month-label'),
                 html.Div(id='date-slider-container', children=date_slider),  # Wrap slider in a Div for styling
                 html.Label("Select Week:", className="fw-bold", style={"color": "#34495e"}, id='week-label'),

--- a/src/components.py
+++ b/src/components.py
@@ -275,7 +275,7 @@ def create_state_summary_graph():
 
 def create_sales_graph():
     return dbc.Card([
-        dbc.CardHeader('Weekly Sales'),
+        dbc.CardHeader(id='sales-chart-header', children='Monthly Sales'),
         dbc.CardBody(dcc.Graph(id='sales', figure={})), 
     ], style={"margin-top": "15px"}) 
 

--- a/src/data.py
+++ b/src/data.py
@@ -60,6 +60,11 @@ def preprocess_data(df):
     # Create a mapping of months to index positions for the slider
     month_labels = {i: label for i, label in enumerate(all_months_sorted)}
 
+    # Create a mapping of weeks
+    weeks = df['year_week'].unique()
+    sorted_weeks = sorted(weeks, key=lambda x: pd.to_datetime(x.split('/')[0]))
+    week_labels = {i: week for i, week in enumerate(sorted_weeks)}
+
     # Filter only last 2 months
     df_month_values = (
         df.groupby('year_month').agg({'Amount': 'sum', 'Qty': 'sum'})
@@ -112,6 +117,7 @@ def preprocess_data(df):
     return {
         "status_mapping": status_mapping,
         "month_labels": month_labels,
+        "week_labels": week_labels,
         "total_revenue_current": total_revenue_current,
         "revenue_mom_change": revenue_mom_change,
         "total_quantity_current": total_quantity_current,


### PR DESCRIPTION
- added a radio button to allow the user to filter between Weekly and Monthly.
- added a `RangeSlider` filter to filter the weeks.
- Newly added filters updates the metrics and the charts.

Merging this PR closes  #74 