### PR TITLE
Add summary sales chart and fixes

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -56,7 +56,8 @@ def update_filtered_data(date_slider_value, week_range_value, promo_filter, fulf
         
         # Filter condition using the list of selected weeks
         filter_condition = f'(year_week in {selected_weeks})'
-        display_date = f"{start_week[-5:]}-{end_week[-5:]}"
+        display_date = f"{start_week[:10]} to {end_week[-10:]}"
+        #print(f"Start {start_week} to {end_week}")
 
     # Apply promotion filter
     if promo_filter:

--- a/src/components.py
+++ b/src/components.py
@@ -322,7 +322,7 @@ def create_map_graph():
 
 def create_state_summary_graph():
     return dbc.Card([
-        dbc.CardHeader('Title'),
+        dbc.CardHeader('Sales by State'),
         dbc.CardBody(dcc.Graph(id='state_summary', figure={}))
     ])
 

--- a/src/components.py
+++ b/src/components.py
@@ -291,7 +291,7 @@ def create_filters(month_labels, week_labels, status_mapping):
                 status_checkbox,
                 html.Br(),
 
-                html.Div(id="filtered-data", style={"font-size": "8px", "font-style": "italic"})
+                html.Div(id="filtered-data", style={"font-size": "12px", "font-style": "italic"})
             ]),
             className="shadow-sm rounded-3 p-4",
             style={"background-color": "#ffffff", "border": "1px solid #ddd", "width": "350px"}  # Reduced width


### PR DESCRIPTION
- This PR closes #71 by adding the new sales summary chart with 7 top categories
- Also fixed #75 increasing the font size of the filter display
- Weekly filter dates were displayed as month and date. For clarity, the weekly filter now displays the full start and end date
