### PR TITLE
fix: change slider labels to show only week dates

### DIFF
--- a/src/assets/tooltip.js
+++ b/src/assets/tooltip.js
@@ -1,0 +1,30 @@
+window.dccFunctions = window.dccFunctions || {};
+
+// Function to get the week start date from the slider value
+window.dccFunctions.getWeekStartDate = function(value) {
+    // Get the week_labels from the hidden Div
+    const weekLabelsElement = document.getElementById("week-labels-data");
+    if (!weekLabelsElement) return value; // Fallback if data isn't found
+    
+    const weekLabelsStr = weekLabelsElement.textContent;
+    let weekLabels;
+    try {
+        weekLabels = JSON.parse(weekLabelsStr.replace(/'/g, '"')); // Convert single quotes to double for valid JSON
+    } catch (e) {
+        return value; // Fallback
+    }
+    
+    // Extract the start date (before the "/") for the given value
+    const weekRange = weekLabels[Math.round(value)]; 
+    if (!weekRange) return value; 
+    
+    // Get the start date from the range
+    const startDate = weekRange.split('/')[0]; // e.g., "2022-03-28"
+    
+    // Extract just the month and day (MM-DD) from the date
+    const dateParts = startDate.split('-');
+    if (dateParts.length !== 3) return value; 
+    
+    // Return as MM-DD format
+    return dateParts[1] + '-' + dateParts[2]; // Returns e.g., "03-28"
+};

--- a/src/assets/tooltip.js
+++ b/src/assets/tooltip.js
@@ -4,27 +4,41 @@ window.dccFunctions = window.dccFunctions || {};
 window.dccFunctions.getWeekStartDate = function(value) {
     // Get the week_labels from the hidden Div
     const weekLabelsElement = document.getElementById("week-labels-data");
-    if (!weekLabelsElement) return value; // Fallback if data isn't found
+    if (!weekLabelsElement) return value; // Fallback
     
     const weekLabelsStr = weekLabelsElement.textContent;
     let weekLabels;
     try {
-        weekLabels = JSON.parse(weekLabelsStr.replace(/'/g, '"')); // Convert single quotes to double for valid JSON
+        weekLabels = JSON.parse(weekLabelsStr.replace(/'/g, '"')); 
     } catch (e) {
         return value; // Fallback
     }
     
-    // Extract the start date (before the "/") for the given value
+    //get the start date 
     const weekRange = weekLabels[Math.round(value)]; 
     if (!weekRange) return value; 
     
-    // Get the start date from the range
+    //start date in the range
     const startDate = weekRange.split('/')[0]; // e.g., "2022-03-28"
     
-    // Extract just the month and day (MM-DD) from the date
+    // extract the year, month, and day from the date
     const dateParts = startDate.split('-');
     if (dateParts.length !== 3) return value; 
     
-    // Return as MM-DD format
-    return dateParts[1] + '-' + dateParts[2]; // Returns e.g., "03-28"
+    const year = dateParts[0];  // e.g., "2022"
+    const month = parseInt(dateParts[1], 10); // e.g., 3 (converted from "03")
+    const day = dateParts[2];   // e.g., "28"
+    
+    //month abbreviations
+    const monthNames = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    ];
+    
+    //get the month abbreviation (subtract 1 because months are 0-indexed in JS Date)
+    const monthAbbr = monthNames[month - 1];
+    if (!monthAbbr) return value; // Fallback if invalid
+    
+    //return the formatted date
+    return monthAbbr + ' ' + parseInt(day, 10); // Remove leading zero from day
 };

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -6,6 +6,8 @@ import dash_bootstrap_components as dbc
 from dash import Input, Output, callback
 from .app import df, month_labels, week_labels, status_mapping, india, cache
 from .components import format_large_num, format_indian_rupees
+import warnings
+warnings.simplefilter(action='ignore', category=UserWarning)
 
 @callback(
     Output("filtered-data", "children"),  # Debugging output

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -359,6 +359,9 @@ def create_map(query, click_data):
     fig.update_layout(
         modebar=dict(remove=['select', 'lasso2d']),
         margin={"r":0,"t":20,"l":0,"b":0},
+        dragmode=False,
+        clickmode='event',
+        hoverdistance=5,
         coloraxis_colorbar=dict(
             x=-0.1,
             y=0.5,

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -341,7 +341,7 @@ def create_map(query, click_data):
     # Custom hover template
     fig.update_traces(
         hovertemplate="%{hovertext}",
-        hovertext=state_sales['State'] + '<br>Amount: ₹' + state_sales['Amount'].apply(lambda x: f'{x/1e6:.1f}M' if x >= 1e6 else f'{x/1e3:.1f}K' if x >= 1e3 else f'{x:.0f}'),
+        hovertext=state_sales.apply(lambda row: f"{row['State']}<br>Amount: {format_indian_rupees(round(row['Amount']))}", axis=1),
     )
 
     # Highlight the selected state

--- a/src/components.py
+++ b/src/components.py
@@ -164,6 +164,26 @@ def create_week_selector(week_labels):
                  "always_visible": True, 
                  "transform": "getWeekStartDate"}
     )
+    # Store the week labels in a hidden div so that we can access them in our js file
+    hidden_data = html.Div(
+        id="week-labels-data",
+        style={"display": "none"},
+        children=[json.dumps(week_labels)]
+    )
+
+    info_text = html.Label(
+        "Showing weeks from 2022",
+        style={
+            "fontSize": "12px",  
+            "color": "white",    
+            "textAlign": "left",  
+            "marginTop": "5px",   
+            "fontStyle": "italic"
+        }
+    )
+    
+    # Return everything in a container
+    return html.Div([slider, hidden_data, info_text])
 
 def create_promotion_toggle():
     """

--- a/src/components.py
+++ b/src/components.py
@@ -151,11 +151,13 @@ def create_week_selector(week_labels):
         dcc.RangeSlider: Range slider component for week selection.
     """
     max_index = max(week_labels.keys())  # Get the maximum index for the slider range
-    return dcc.RangeSlider(
+    custom_marks = {i: {"label": "", "style": {"display": "none"}} for i in range(max_index + 1)} # Hide all marks
+
+    slider = dcc.RangeSlider(
         id="week-range-slider",
         min=0,
         max=max_index,
-        marks={i: {"label": str(i), "style": {"color": "white"}} for i in week_labels.keys()},
+        marks=custom_marks,
         step=1,
         value=[3, 9],  # Default range
         tooltip={"placement": "bottom", "always_visible": True}

--- a/src/components.py
+++ b/src/components.py
@@ -323,10 +323,17 @@ def create_metrics():
 def create_map_graph():
     return dbc.Card([
         dbc.CardHeader('Map of India'),
-        dbc.CardBody(dcc.Graph(id='map', figure={}, 
-                              style={'cursor': 'pointer'},
-                              config={'displayModeBar': True}))
-        ], style={"margin-top": "5px"})
+        dbc.CardBody([
+            html.Div(
+                dcc.Graph(
+                    id='map',
+                    figure={},
+                    config={'displayModeBar': True}
+                ),
+                style={'cursor': 'pointer'}
+            )
+        ])
+    ], style={"margin-top": "5px"})
 
 def create_state_summary_graph():
     return dbc.Card([

--- a/src/components.py
+++ b/src/components.py
@@ -2,6 +2,7 @@ import dash_bootstrap_components as dbc
 from dash import html, dcc
 from git import Repo
 from datetime import datetime
+import json
 
 # Function to format numeric values
 def format_large_num(value):

--- a/src/components.py
+++ b/src/components.py
@@ -323,8 +323,10 @@ def create_metrics():
 def create_map_graph():
     return dbc.Card([
         dbc.CardHeader('Map of India'),
-        dbc.CardBody(dcc.Graph(id='map', figure={}))
-        ], style={"margin-top": "5px"}) 
+        dbc.CardBody(dcc.Graph(id='map', figure={}, 
+                              style={'cursor': 'pointer'},
+                              config={'displayModeBar': True}))
+        ], style={"margin-top": "5px"})
 
 def create_state_summary_graph():
     return dbc.Card([

--- a/src/components.py
+++ b/src/components.py
@@ -160,7 +160,9 @@ def create_week_selector(week_labels):
         marks=custom_marks,
         step=1,
         value=[3, 9],  # Default range
-        tooltip={"placement": "bottom", "always_visible": True}
+        tooltip={"placement": "bottom", 
+                 "always_visible": True, 
+                 "transform": "getWeekStartDate"}
     )
 
 def create_promotion_toggle():


### PR DESCRIPTION
- Created a new `tooltip.js` file to hold our custom transform function.
- Shows only the start week dates as tooltips 
- Hide ticks

Known Issue:  Some weeks' tooltip overlaps with each other and are not very readable (#124)


closes #118